### PR TITLE
Category roots in menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ interface StoryMeta {
   /** Affects position of link to story in menu, greater values makes links upper. */
   menuPriority?: number;
 
+  /**
+   * For menu item of story it means that it will not be shown in menu.
+   * For "Category root" it means that click will not be open it.
+   */
+  menuPriority?: number;
+
   /** Parameters of building or/and displaying story */
   parameters?: {
     /**
@@ -88,6 +94,19 @@ interface StoryMeta {
         };
   };
 }
+```
+
+#### Meta: How to create category root?
+
+In menu categories will be shown as headers of item groups.
+
+To make it header as link to category root you need to set name of story as empty string (`''`):
+
+```jsx
+export const meta = {
+  category: 'My category'
+  title: '',
+};
 ```
 
 In JavaScript/TypeScript files you can just export `meta` with meta data.

--- a/src/build/emit-stories-entrypoint.ts
+++ b/src/build/emit-stories-entrypoint.ts
@@ -23,8 +23,6 @@ export async function emitStoriesEntrypoint(config: EmitStoriesEntrypointConfig)
 
     // создаем файл точки входа
     .then(content => fs.writeFile(filename, content));
-
-  // console.log('Stories entrypoint emit: done');
 }
 
 function getPageDataFactory(config: EmitStoriesEntrypointConfig) {

--- a/src/core/schemas.ts
+++ b/src/core/schemas.ts
@@ -11,6 +11,7 @@ export const StoryMetaSchema = z.object({
   title: z.string().optional(),
   category: z.string().optional(),
   menuPriority: z.number().int().finite().optional(),
+  menuHidden: z.boolean().optional(),
   parameters: z
     .object({
       layout: z.enum(['padded', 'fullscreen']).optional(),

--- a/src/runtime-showcase/components/App/App.tsx
+++ b/src/runtime-showcase/components/App/App.tsx
@@ -51,18 +51,27 @@ export function App() {
                 return `?path=${data.story.pathname}`;
               }}
               isActive={data => {
-                if (data.type !== 'story') {
-                  return false;
-                }
-
-                return data.story.pathname === location.pathname;
+                return !!data.story && data.story?.pathname === location.pathname;
+              }}
+              isInteractive={data => {
+                return !!data.story && !data.story.meta?.menuHidden;
               }}
               onItemClick={(event, data) => {
-                if (data.type === 'story' && location.pathname !== data.story.pathname) {
+                if (data.type === 'story' && !data.menuHidden) {
                   event.preventDefault();
                   navigate(data.story.pathname);
-                } else if (data.type === 'story') {
+                  return;
+                }
+
+                if (data.type === 'group' && data.story && !data.story.meta?.menuHidden) {
                   event.preventDefault();
+                  navigate(data.story.pathname);
+                  return;
+                }
+
+                if (data.type === 'story') {
+                  event.preventDefault();
+                  return;
                 }
               }}
             />

--- a/src/runtime-showcase/components/Menu/Menu.m.css
+++ b/src/runtime-showcase/components/Menu/Menu.m.css
@@ -15,7 +15,7 @@
   background: var(--showcase-ui-menuitem-background, none);
 }
 
-.menuitem:not(.active) > .menuitemTitle:hover {
+.menuitem:not(.active) > .menuitemTitle.interactive:hover {
   cursor: pointer;
   color: var(--showcase-ui-menuitem-color, #000);
   background: var(--showcase-ui-menuitem-background, #f2f3f6);

--- a/src/runtime-showcase/components/Menu/Menu.tsx
+++ b/src/runtime-showcase/components/Menu/Menu.tsx
@@ -22,6 +22,7 @@ export interface MenuProps<T> {
   getHref?: (item: T) => string | undefined;
   getChildItems?: (item: T) => T[];
   isActive?: (item: T) => boolean;
+  isInteractive?: (item: T) => boolean;
   onItemClick?: (event: MouseEvent<HTMLElement>, data: T) => void;
 }
 
@@ -43,6 +44,7 @@ export function Menu<T>({
   getTitle,
   getHref,
   isActive,
+  isInteractive,
   onItemClick,
   getChildItems,
 }: MenuProps<T>) {
@@ -68,6 +70,7 @@ export function Menu<T>({
                 paddingLeft: depth >= 2 ? `${1 + (depth - 1) * 1.25}rem` : `1rem`,
               }}
               className={toplevel ? styles.bold : undefined}
+              interactive={isInteractive?.(item)}
             >
               {!toplevel && childItems.length > 0 && <FaChevronRight className={styles.icon} />}
               {(getTitle ?? String)(item)}
@@ -139,16 +142,19 @@ export function MenuItem({
 }
 
 export function MenuItemTitle({
+  interactive = true,
   children,
   className,
   onClick,
   ...restProps
-}: AnchorHTMLAttributes<HTMLAnchorElement>) {
+}: AnchorHTMLAttributes<HTMLAnchorElement> & {
+  interactive?: boolean;
+}) {
   const { store, controlled } = useContext(MenuItemContext);
 
   return (
     <a
-      className={classNames(styles.menuitemTitle, className)}
+      className={classNames(styles.menuitemTitle, interactive && styles.interactive, className)}
       onClick={event => {
         onClick?.(event);
 

--- a/src/runtime-showcase/components/MenuModal/MenuModal.tsx
+++ b/src/runtime-showcase/components/MenuModal/MenuModal.tsx
@@ -51,19 +51,28 @@ export function MenuModal({ open, onClose }: MenuModalProps) {
             return defineStoryUrl(data.story);
           }}
           isActive={data => {
-            if (data.type !== 'story') {
-              return false;
-            }
-
-            return data.story.pathname === location.pathname;
+            return !!data.story && data.story?.pathname === location.pathname;
+          }}
+          isInteractive={data => {
+            return !!data.story && !data.story.meta?.menuHidden;
           }}
           onItemClick={(event, data) => {
-            if (data.type === 'story' && location.pathname !== data.story.pathname) {
+            if (data.type === 'story' && !data.menuHidden) {
               event.preventDefault();
               navigate(data.story.pathname);
               onClose?.();
-            } else if (data.type === 'story') {
+              return;
+            }
+
+            if (data.type === 'group' && data.story && !data.story.meta?.menuHidden) {
               event.preventDefault();
+              navigate(data.story.pathname);
+              return;
+            }
+
+            if (data.type === 'story') {
+              event.preventDefault();
+              return;
             }
           }}
         />


### PR DESCRIPTION
- now it is possible to make _"category root"_ - clickable header of list in menu that redirect to story
- `menuPriority` now affects categories order