### PR TITLE
Logo for dark mode and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ const storiesConfig = {
   // where stories entrypoint will be emitted
   filename: './.generated/entries.js',
 
-  // glob patter for find all story modules
+  // glob pattern for find all story modules
   storiesGlob: './stories/**/*.story.{mdx,tsx}',
 
   // root dir of all story modules

--- a/src/runtime-showcase/components/app/app.tsx
+++ b/src/runtime-showcase/components/app/app.tsx
@@ -60,7 +60,7 @@ export function App(): ReactNode {
           <HeaderLinks />
         </Header>
 
-        {!mobile && currentStory?.isAsideEnabled() && (
+        {!mobile && (!currentStory || currentStory?.isAsideEnabled()) && (
           <Aside>
             {processedProps.storySearch && (
               <div className={styles.search}>
@@ -137,7 +137,7 @@ export function App(): ReactNode {
           </Aside>
         )}
 
-        <Main fullWidth={!currentStory?.isAsideEnabled()}>
+        <Main fullWidth={!(!currentStory || currentStory?.isAsideEnabled())}>
           {!currentStory && <StoryPlaceholder />}
           {currentStory && <StoryViewer story={currentStory} defineStoryUrl={defineStoryUrl} />}
         </Main>

--- a/src/runtime-showcase/components/app/app.tsx
+++ b/src/runtime-showcase/components/app/app.tsx
@@ -152,7 +152,7 @@ function useTheme() {
   const { processedProps } = useContext(ShowcaseContext);
 
   const isDefaultDark = useMatchMedia('(prefers-color-scheme: dark)');
-  const defaultTheme = isDefaultDark ? 'dark' : 'light';
+  const defaultTheme = processedProps.themes.enabled && isDefaultDark ? 'dark' : 'light';
 
   const [savedTheme, setTheme] = useStorageItem('showcase:theme', {
     storage: localStorage,

--- a/src/runtime-showcase/components/header-links/header-links.tsx
+++ b/src/runtime-showcase/components/header-links/header-links.tsx
@@ -8,12 +8,12 @@ import styles from './header-links.m.css';
 
 export function HeaderButtons(): ReactNode {
   const { processedProps, toggleMenu: toggleMenuModal } = useContext(ShowcaseContext);
-  const { headerLinks, themes: themesEnabled } = processedProps;
+  const { headerLinks, themes } = processedProps;
   const mobile = useMatchMedia('(max-width: 960px)');
 
   return (
     <div className={styles.root}>
-      {themesEnabled && <ThemeToggle />}
+      {themes.enabled && <ThemeToggle />}
 
       {!mobile && (
         <>

--- a/src/runtime-showcase/components/standalone-provider/standalone-provider.tsx
+++ b/src/runtime-showcase/components/standalone-provider/standalone-provider.tsx
@@ -1,5 +1,5 @@
 import { type StoryModule } from '#core';
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { type AnyMenuNode, getMenuItems } from '../../utils/menu';
 import { QueryRouter, RouterContext } from '../../shared/router';
 import { ShowcaseContext, type ShowcaseContextValue } from '../../context/showcase';
@@ -23,6 +23,8 @@ export interface StandaloneAppProps {
 
   /** Enables search by stories in sidebar and mobile modal menu. */
   storySearch?: boolean;
+
+  defaultStory?: { pathname: string };
 
   /** Enables switch between light and dark themes. */
   themes?:
@@ -52,12 +54,19 @@ export function StandaloneProvider(props: StandaloneProviderProps): ReactNode {
     //
     children,
     stories,
+    defaultStory,
     defineStoryUrl = defaultDefineStoryUrl,
   } = props;
 
   const [menuOpen, toggleMenu] = useState(false);
 
+  const defaultStoryRef = useRef(defaultStory);
+
   const defaultPathname = useMemo(() => {
+    if (defaultStoryRef.current?.pathname) {
+      return defaultStoryRef.current.pathname;
+    }
+
     const findFirstStory = (items: AnyMenuNode[]): string => {
       for (const item of items) {
         if (item.type === 'story') {
@@ -71,7 +80,7 @@ export function StandaloneProvider(props: StandaloneProviderProps): ReactNode {
     };
 
     return findFirstStory(getMenuItems(stories));
-  }, [stories]);
+  }, [defaultStoryRef, stories]);
 
   const contextValue: ShowcaseContextValue = {
     processedProps: {

--- a/src/runtime-showcase/components/story-mdx-viewer/story-mdx-viewer.m.css
+++ b/src/runtime-showcase/components/story-mdx-viewer/story-mdx-viewer.m.css
@@ -155,3 +155,8 @@
   margin-bottom: 0;
   color: var(--showcase-ui-mdx-blockquote-color, #aaa);
 }
+
+.mdx i,
+.mdx em {
+  font-style: italic;
+}

--- a/src/runtime-showcase/utils/menu.ts
+++ b/src/runtime-showcase/utils/menu.ts
@@ -90,7 +90,7 @@ function groupStoriesByFirstSegment(state: AnyMenuNode[], node: AnyMenuNode): An
   };
 
   // если нет имени группы оставляем узел на том уровне на котором он был
-  if (groupName === '') {
+  if (groupName === '' && !node.menuHidden) {
     state.push(newNode);
     return state;
   }


### PR DESCRIPTION
- `defaultStory` option in showcase
- `menuHidden` now affects non group menu nodes
- style for `i, em` as italic in MDX view
- `aside` display fixed for not found page
- theme toggle showing fix
- default theme defining fix